### PR TITLE
107 create action to run tests

### DIFF
--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -24,7 +24,7 @@ jobs:
         run: go get .
         working-directory: ./minitwit-api
       - name: build
-        run: go build -o ../app .
+        run: go build -o ./app .
         working-directory: ./minitwit-api
 
       - name: Set up Python
@@ -35,6 +35,6 @@ jobs:
       - name: Test with pytest
         working-directory: ./tests/legacy_api_tests
         run: |
-          nohup ../../app&
+          nohup ../../minitwit-api/app&
           pip install pytest pytest-cov requests
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Test with pytest
+        working-directory: ./tests/legacy_api_tests/minitwit-api
         run: |
           pip install pytest pytest-cov
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Test with pytest
         working-directory: ./tests/legacy_api_tests
         run: |
-          nohup ./app&
+          nohup ../../app&
           pip install pytest pytest-cov requests
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -27,7 +27,7 @@ jobs:
         run: go build -o ../app .
         working-directory: ./minitwit-api
       - name: run
-        run: nohup ./app
+        run: nohup ./app&
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -36,6 +36,6 @@ jobs:
       - name: Test with pytest
         working-directory: ./tests/legacy_api_tests
         run: |
-          ls
+          ls ../../
           pip install pytest pytest-cov requests
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -36,5 +36,5 @@ jobs:
       - name: Test with pytest
         working-directory: ./tests/legacy_api_tests
         run: |
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov requests
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -26,16 +26,15 @@ jobs:
       - name: build
         run: go build -o ../app .
         working-directory: ./minitwit-api
-      - name: run
-        run: nohup ./app&
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+
       - name: Test with pytest
         working-directory: ./tests/legacy_api_tests
         run: |
-          ls ../../
+          nohup ./app&
           pip install pytest pytest-cov requests
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -12,6 +12,7 @@ jobs:
 
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsworking-directory
     steps:
       - name: Setup Go 1.21.x
         uses: actions/setup-go@v4
@@ -20,9 +21,11 @@ jobs:
           go-version: '1.21.x'
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: go get ./minitwit-api
+        run: go get .
+        working-directory: ./minitwit-api
       - name: build
-        run: go build ./minitwit-api -o app
+        run: go build . -o ../app
+        working-directory: ./minitwit-api
       - name: run
         run: ./app&
 

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -1,7 +1,7 @@
 name: Run tests on PR
 
 on:
-  push:
+  pull_request:
     branches:
       - 107-create-action-to-run-tests
   

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Test with pytest
         working-directory: ./minitwit-api
         run: |
-          nohup app&
+          nohup ./app&
           pip install pytest pytest-cov requests
           pytest ../tests/legacy_api_tests/minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -1,0 +1,36 @@
+name: Run tests on PR
+
+on:
+  push:
+    branches:
+      - 107-create-action-to-run-tests
+  
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+    steps:
+      - name: Setup Go 1.21.x
+        uses: actions/setup-go@v4
+        with:
+          # Semantic version range syntax or exact version of Go
+          go-version: '1.21.x'
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: go get ./minitwit-api
+      - name: build
+        run: go build ./minitwit-api -o app
+      - name: run
+        run: ./app&
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Test with pytest
+        run: |
+          pip install pytest pytest-cov
+          pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -24,7 +24,7 @@ jobs:
         run: go get .
         working-directory: ./minitwit-api
       - name: build
-        run: go build . -o ../app
+        run: go build -o ../app .
         working-directory: ./minitwit-api
       - name: run
         run: ./app&

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Test with pytest
-        working-directory: ./tests/legacy_api_tests/minitwit-api
+        working-directory: ./tests/legacy_api_tests
         run: |
           pip install pytest pytest-cov
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -3,7 +3,7 @@ name: Run tests on PR
 on:
   pull_request:
     branches:
-      - 107-create-action-to-run-tests
+      - main
   
 
 jobs:

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -27,7 +27,7 @@ jobs:
         run: go build -o ../app .
         working-directory: ./minitwit-api
       - name: run
-        run: ./app&
+        run: nohup ./app
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -36,5 +36,6 @@ jobs:
       - name: Test with pytest
         working-directory: ./tests/legacy_api_tests
         run: |
+          ls
           pip install pytest pytest-cov requests
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Test with pytest
         working-directory: ./tests/legacy_api_tests
         run: |
+          ls ../../minitwit-api
           nohup ../../minitwit-api/app&
           pip install pytest pytest-cov requests
           pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/.github/workflows/run_tests_on_pr.yaml
+++ b/.github/workflows/run_tests_on_pr.yaml
@@ -33,9 +33,8 @@ jobs:
           python-version: '3.x'
 
       - name: Test with pytest
-        working-directory: ./tests/legacy_api_tests
+        working-directory: ./minitwit-api
         run: |
-          ls ../../minitwit-api
-          nohup ../../minitwit-api/app&
+          nohup app&
           pip install pytest pytest-cov requests
-          pytest minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+          pytest ../tests/legacy_api_tests/minitwit_sim_api_test.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html


### PR DESCRIPTION
This took a few tries, but now there is a workflow that will:
build go code
run compiled go code in background
run pytest

if pytest fails tests we can have a check blocking a pr.

Ideally docker would have been a part of this so we now we don't change the setup in a way that breaks the dockerfiles or compose, ie folder renaming.
This seemed a little tricky to set up, so for a start we can test against the build.