### PR TITLE
Db cleanup

### DIFF
--- a/minitwit-api/api/delete-api.go
+++ b/minitwit-api/api/delete-api.go
@@ -28,11 +28,10 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	if !db.IsNil(rv.User) && r.Method == "POST" {
 		toDeleteUsername := rv.User
 		toDeleteUser_id, _ := db.Get_user_id(toDeleteUsername)
+
 		query := `DELETE FROM user WHERE user_id = ?`
 
-		sqlite_db, _ := db.Connect_db()
-
-		_, err = sqlite_db.Exec(query, toDeleteUser_id)
+		err = db.DoExec(query, []any{toDeleteUser_id})
 
 		fmt.Println(err)
 	}

--- a/minitwit-api/api/follow-api.go
+++ b/minitwit-api/api/follow-api.go
@@ -47,12 +47,9 @@ func Follow(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		query := `INSERT INTO follower (who_id, whom_id) VALUES (?, ?)`
-		sqlite_db, _ := db.Connect_db()
-		defer sqlite_db.Close()
-		_, err := sqlite_db.Exec(query, user_id, follow_user_id)
+		err := db.DoExec(query, []any{user_id, follow_user_id})
 
 		if err != nil {
-			fmt.Println("Error querying the database")
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -69,11 +66,11 @@ func Follow(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		query := `DELETE FROM follower WHERE who_id=? and WHOM_id=?`
-		sqlite_db, _ := db.Connect_db()
-		defer sqlite_db.Close()
-		_, err = sqlite_db.Exec(query, user_id, unfollow_user_id)
 
-		json.NewEncoder(w).Encode(http.StatusOK)
+		err = db.DoExec(query, []any{user_id, unfollow_user_id})
+		if err != nil {
+			json.NewEncoder(w).Encode(http.StatusOK)
+		}
 
 	} else if r.Method == "GET" {
 		followees := db.GetFollowees([]any{user_id, no_flws}, false)

--- a/minitwit-api/api/message-api.go
+++ b/minitwit-api/api/message-api.go
@@ -72,17 +72,11 @@ func Messages_per_user(w http.ResponseWriter, r *http.Request) {
 			fmt.Println("Error in decoding the JSON, message", err)
 		}
 
-		sqlite_db, err := db.Connect_db()
-		defer sqlite_db.Close()
-
 		query := `INSERT INTO message (author_id, text, pub_date, flagged)
 		VALUES (?, ?, ?, 0)`
 
-		_, err = sqlite_db.Exec(query, user_id, rv.Content, int(time.Now().Unix()))
-		if err != nil {
-			fmt.Println("Error when trying to insert data into the database")
-			return
-		}
+		db.DoExec(query, []any{user_id, rv.Content, int(time.Now().Unix())})
+
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/minitwit-api/api/message-api.go
+++ b/minitwit-api/api/message-api.go
@@ -75,9 +75,10 @@ func Messages_per_user(w http.ResponseWriter, r *http.Request) {
 		query := `INSERT INTO message (author_id, text, pub_date, flagged)
 		VALUES (?, ?, ?, 0)`
 
-		db.DoExec(query, []any{user_id, rv.Content, int(time.Now().Unix())})
-
-		w.WriteHeader(http.StatusNoContent)
+		dberr := db.DoExec(query, []any{user_id, rv.Content, int(time.Now().Unix())})
+		if dberr != nil {
+			w.WriteHeader(http.StatusNoContent)
+		}
 	}
 }
 

--- a/minitwit-api/api/register-api.go
+++ b/minitwit-api/api/register-api.go
@@ -35,23 +35,14 @@ func Register(w http.ResponseWriter, r *http.Request) {
 		} else if !db.IsNil(user_id) {
 			errMsg = "The username is already taken"
 		} else {
-			sqlite_db, err := db.Connect_db()
-			defer sqlite_db.Close()
-			if err != nil {
-				fmt.Println("Error when connecting to the database")
-				return
-			}
 			hash_pw, err := db.HashPassword(rv.Pwd)
 			if err != nil {
 				fmt.Println("Error hashing the password")
 				return
 			}
 			query := "INSERT INTO user (username, email, pw_hash) VALUES (?, ?, ?)"
-			_, err = sqlite_db.Exec(query, rv.Username, rv.Email, hash_pw)
-			if err != nil {
-				fmt.Println("Error when trying to insert data into the database")
-				return
-			}
+			db.DoExec(query, []any{rv.Username, rv.Email, hash_pw})
+
 		}
 		if errMsg != "" {
 			Response := struct {

--- a/minitwit-api/db/db-facade.go
+++ b/minitwit-api/db/db-facade.go
@@ -17,6 +17,19 @@ func Connect_db() (db *sql.DB, err error) {
 	return sql.Open("sqlite3", DATABASE)
 }
 
+func DoExec(query string, args []any) {
+	db, _ := Connect_db()
+
+	db.Close()
+
+	_, err := db.Exec(query, args)
+	if err != nil {
+		fmt.Println("Error when trying to insert data into the database")
+		return
+	}
+
+}
+
 func GetMessages(args []any, one bool) []map[string]any {
 	query := `SELECT message.*, user.* FROM message, user
         WHERE message.flagged = 0 AND message.author_id = user.user_id

--- a/minitwit-api/db/db-facade.go
+++ b/minitwit-api/db/db-facade.go
@@ -17,17 +17,17 @@ func Connect_db() (db *sql.DB, err error) {
 	return sql.Open("sqlite3", DATABASE)
 }
 
-func DoExec(query string, args []any) {
+func DoExec(query string, args []any) error { //used for all post request
 	db, _ := Connect_db()
 
-	db.Close()
+	defer db.Close()
 
-	_, err := db.Exec(query, args)
+	_, err := db.Exec(query, args...)
 	if err != nil {
 		fmt.Println("Error when trying to insert data into the database")
-		return
+		return err
 	}
-
+	return err
 }
 
 func GetMessages(args []any, one bool) []map[string]any {


### PR DESCRIPTION
Moved DB logic to db-facade.go for POST requests.
query strings are still defined in api, this enables us to only have a singular method in db-facade.go for all POST requests. handling of DB errors are also moved to db-facade.go