### PR TITLE
fixed simulator error by passing flagged variable to doExec

### DIFF
--- a/minitwit-api/api/message-api.go
+++ b/minitwit-api/api/message-api.go
@@ -75,7 +75,7 @@ func Messages_per_user(w http.ResponseWriter, r *http.Request) {
 		query := `INSERT INTO message (author_id, text, pub_date, flagged)
 		VALUES (?, ?, ?, 0)`
 
-		dberr := db.DoExec(query, []any{user_id, rv.Content, int(time.Now().Unix())})
+		dberr := db.DoExec(query, []any{user_id, rv.Content, int(time.Now().Unix()), 0})
 		if dberr != nil {
 			w.WriteHeader(http.StatusNoContent)
 		}


### PR DESCRIPTION
Forcefully passing the flagged variable to the query seems to do the trick