### PR TITLE
Remove constant uninformative logging when connecting to db

### DIFF
--- a/minitwit-api/db/db-facade.go
+++ b/minitwit-api/db/db-facade.go
@@ -50,8 +50,6 @@ func Connect_db() (db *sql.DB, err error) {
 		}
 	}
 
-	fmt.Println("Connecting to database...")
-	fmt.Println("dbPath:" + dbPath)
 	return sql.Open("sqlite3", dbPath)
 }
 


### PR DESCRIPTION
#132 

Small change, stops the log from looking like this: 

dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db
Connecting to database...
dbPath:/usr/src/app/sqlitedb/minitwit.db