### PR TITLE
optimizing the password hashing

### DIFF
--- a/minitwit-api/api/register-api.go
+++ b/minitwit-api/api/register-api.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/cespare/xxhash"
+
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -35,14 +37,13 @@ func Register(w http.ResponseWriter, r *http.Request) {
 		} else if !db.IsNil(user_id) {
 			errMsg = "The username is already taken"
 		} else {
-			hash_pw, err := db.HashPassword(rv.Pwd)
+			hash_pw := hashPassword(rv.Pwd)
 			if err != nil {
 				fmt.Println("Error hashing the password")
 				return
 			}
 			query := "INSERT INTO user (username, email, pw_hash) VALUES (?, ?, ?)"
 			db.DoExec(query, []any{rv.Username, rv.Email, hash_pw})
-
 		}
 		if errMsg != "" {
 			Response := struct {
@@ -58,4 +59,11 @@ func Register(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		}
 	}
+}
+
+func hashPassword(password string) string {
+	hashed := xxhash.Sum64([]byte(password))
+	hashedStr := fmt.Sprintf("%d", hashed)
+
+	return hashedStr
 }


### PR DESCRIPTION
Co-authored by: Trond Rossing trondrossing@gmail.com 
Co-authored by: ChatGPT

 Password hashing was the reason why register failed with read timeout. 
 After changing the hashing from bcryt to xxhash, it succeeds. 