### PR TITLE
corrected test: changed response code to 204 for tweet

### DIFF
--- a/tests/legacy_api_tests/minitwit_sim_api_test.py
+++ b/tests/legacy_api_tests/minitwit_sim_api_test.py
@@ -71,7 +71,7 @@ def test_get_latest_user_msgs():
         query = {'no': 20, 'latest': 3}
         url = f'{BASE_URL}/msgs/{username}'
         response = requests.get(url, headers=HEADERS, params=query)
-        assert response.status_code == 200, response
+        assert response.status_code == 204, response
 
         got_it_earlier = False
         for msg in response.json():


### PR DESCRIPTION
Simulator expects: 
Tweets: 204
Msgs: 200 

The failed test is for tweet, and I can see that test expects 200, whereas simulator expects 204 
I guess we should change the test to 204 to make is consistent with what simulator expects.
Otherwise, the PR cannot get approved and we will still be failing the simulator
