### PR TITLE
Cron job to backup the database

### DIFF
--- a/minitwit-api/go.mod
+++ b/minitwit-api/go.mod
@@ -7,13 +7,14 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22
 )
 
-require golang.org/x/crypto v0.19.0
+require (
+	github.com/cespare/xxhash v1.1.0
+	github.com/robfig/cron/v3 v3.0.1
+	gorm.io/driver/sqlite v1.5.5
+	gorm.io/gorm v1.25.7
+)
 
 require (
-	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	golang.org/x/sys v0.17.0 // indirect
-	gorm.io/driver/sqlite v1.5.5 // indirect
-	gorm.io/gorm v1.25.7 // indirect
 )

--- a/minitwit-api/minitwit-api.go
+++ b/minitwit-api/minitwit-api.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"minitwit-api/api"
 
 	"github.com/gorilla/mux"
 
 	"minitwit-api/db"
+
+	"os/exec"
+
+	"github.com/robfig/cron/v3"
 )
 
 func main() {
@@ -24,9 +29,35 @@ func main() {
 	r.HandleFunc("/cleandb", api.Cleandb)
 	r.HandleFunc("/delete", api.Delete)
 
+	c := cron.New()
+	if c == nil {
+		log.Fatal("Error creating cron instance")
+	}
+	c.AddFunc("*/15 * * * *", backup)
+	c.Start()
+	defer c.Stop()
+
 	fmt.Println("Listening on port 15001...")
 	err := http.ListenAndServe(":15001", r)
 	if err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
+}
+
+func backup() {
+	fmt.Println("Starting backup of the database...")
+
+	if err := os.MkdirAll("./backups", 0755); err != nil {
+		fmt.Printf("Error creating destination directory: %s\n", err)
+		return
+	}
+	cmd := exec.Command("scp", "-i", "~/.ssh/terraform", "-o", "StrictHostKeyChecking=no", "root@188.166.201.66:/tmp/sqlitedb-api/minitwit.db", "./backups/minitwit.db")
+
+	err := cmd.Run()
+	if err != nil {
+		fmt.Printf("Error running scp command: %s\n", err)
+		return
+	}
+
+	fmt.Println("Backup completed successfully")
 }

--- a/minitwit-api/minitwit-api.go
+++ b/minitwit-api/minitwit-api.go
@@ -5,14 +5,13 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
 
 	"minitwit-api/api"
 
 	"github.com/gorilla/mux"
 
 	"minitwit-api/db"
-
-	"os/exec"
 
 	"github.com/robfig/cron/v3"
 )


### PR DESCRIPTION
#165 

- Added cron job to backup the db 
- Copies the remote database to the /backups folder in our repo
- Cron schedule is every 15 minutes

Can be integrated with DigitalOcean Spaces for cloud storage

Co-authored by: ChatGPT
