### PR TITLE
updated path to minitwit.db in connect_db()

### DIFF
--- a/minitwit-api/db/db-facade.go
+++ b/minitwit-api/db/db-facade.go
@@ -18,7 +18,7 @@ var db *gorm.DB
 func Connect_db() {
 	dbPath := os.Getenv("SQLITEPATH")
 	if len(dbPath) == 0 {
-		dbPath = "./sqlite/minitwit.db"
+		dbPath = "./minitwit.db"
 	}
 
 	dir := filepath.Dir(dbPath)


### PR DESCRIPTION
Co-authored by: Rasmus Nordbjærg
Co-authored by: Roman

/sqlite/minitwit.db does not exist, so we updated the path to minitwit-api/minitwit.db in connect_db()