### PR TITLE
217 scalability sim endpoint

### DIFF
--- a/minitwit-api/api/getlatest-api.go
+++ b/minitwit-api/api/getlatest-api.go
@@ -2,29 +2,21 @@ package api
 
 import (
 	"encoding/json"
+	"minitwit-api/db"
 	"net/http"
-	"os"
-	"strconv"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func Get_latest(w http.ResponseWriter, r *http.Request) {
 	lg.Info("Get latest handler invoked ")
-	content, err := os.ReadFile("./latest_processed_sim_action_id.txt")
+	db, err := db.GetDb()
 	if err != nil {
-		lg.Error("Error reading sim file: ", err)
+		lg.Fatal("Could not get database", err)
 	}
-
-	latest_command_id, err := strconv.Atoi(string(content))
-	if err != nil {
-		lg.Error("Error converting string to int: ", err)
-		latest_command_id = -1
-	}
+	count := db.GetCount("sim")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(struct {
 		Latest int `json:"latest"`
 	}{
-		Latest: latest_command_id,
+		Latest: count,
 	})
 }

--- a/minitwit-api/db/idb.go
+++ b/minitwit-api/db/idb.go
@@ -19,4 +19,7 @@ type Idb interface {
 	GetAllUsers() []model.User
 	GetAllFollowers() []model.Follower
 	GetAllMessages() []model.Message
+
+	GetCount(key string) int
+	SetCount(key string, value int) error
 }

--- a/minitwit-api/db/sqlitedb/db-facade.go
+++ b/minitwit-api/db/sqlitedb/db-facade.go
@@ -288,6 +288,16 @@ func (sqliteImpl *SqliteDbImplementation) GetAllFollowers() []model.Follower {
 	return followers
 }
 
+// GetCount implements db.Idb.
+func (sqliteImpl *SqliteDbImplementation) GetCount(key string) int {
+	panic("unimplemented")
+}
+
+// SetCount implements db.Idb.
+func (sqliteImpl *SqliteDbImplementation) SetCount(key string, value int) error {
+	panic("unimplemented")
+}
+
 func (sqliteImpl *SqliteDbImplementation) IsNil(i interface{}) bool {
 	if i == nil || i == interface{}(nil) {
 		return true

--- a/minitwit-api/db/sqlitedb/db-facade.go
+++ b/minitwit-api/db/sqlitedb/db-facade.go
@@ -94,7 +94,7 @@ func (sqliteImpl *SqliteDbImplementation) Connect_db() {
 		readWritesDatabase.WithLabelValues("Connect_db", "connect", "fail").Inc()
 		return
 	}
-	sqliteImpl.db.AutoMigrate(&model.User{}, &model.Follower{}, &model.Message{})
+	sqliteImpl.db.AutoMigrate(&model.User{}, &model.Follower{}, &model.Message{}, &model.Count{})
 	readWritesDatabase.WithLabelValues("Connect_db", "connect", "success").Inc()
 
 	sqliteUserGauge.Set(sqliteImpl.QueryUserCount())

--- a/minitwit-api/model/Count.go
+++ b/minitwit-api/model/Count.go
@@ -1,0 +1,6 @@
+package model
+
+type Count struct {
+	Key   string `json:"key" gorm:"primaryKey"`
+	Value int    `json:"value"`
+}

--- a/minitwit-api/sim/sim-facade.go
+++ b/minitwit-api/sim/sim-facade.go
@@ -2,15 +2,24 @@ package sim
 
 import (
 	"encoding/json"
+	"minitwit-api/db"
+	"minitwit-api/logger"
 	"net/http"
-	"os"
+	"strconv"
 )
+
+var lg = logger.InitializeLogger()
 
 func UpdateLatest(r *http.Request) {
 	r.ParseForm()
 	latest := r.Form.Get("latest")
 	if latest != "" {
-		_ = os.WriteFile("./latest_processed_sim_action_id.txt", []byte((latest)), 0644)
+		db, err := db.GetDb()
+		if err != nil {
+			lg.Fatal("Failed to get DB", err)
+		}
+		val, _ := strconv.Atoi(latest)
+		db.SetCount("sim", val)
 	}
 }
 


### PR DESCRIPTION
Using a generic table for counts of on the form <key,value> <string,int>
Currently the counts are saved to file in the container and not persisted in a volume, so there is no point in transferring the current sim count to postgres.



![image](https://github.com/Eagles-DevOps/MiniTwit/assets/16220541/cff2d910-7284-49f0-ae87-c00389fcbf84)

![image](https://github.com/Eagles-DevOps/MiniTwit/assets/16220541/1f66ba81-052b-4b03-81ad-8059ded60962)

