### PR TITLE
use multistage builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - POSTGRES_DISABLE_SSL=true
     depends_on:
       - postgres
-    command: ["./wait-for-it.sh", "postgres:5432", "--", "/usr/local/bin/app"]
+    command: ["./wait-for-it.sh", "postgres:5432", "--", "/minitwit/app"]
 
   minitwit_api:
     build: ./minitwit-api

--- a/minitwit-api/Dockerfile
+++ b/minitwit-api/Dockerfile
@@ -1,8 +1,6 @@
-FROM golang:1.22
+FROM golang:1.22-alpine3.19 AS Build
 
 WORKDIR /usr/src/app
-ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh wait-for-it.sh
-RUN chmod +x wait-for-it.sh
 
 # pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
 COPY *.go go.mod go.sum ./
@@ -10,5 +8,14 @@ RUN go mod download && go mod verify
 
 COPY . .
 RUN go build -v -o /minitwit/app .
+
+
+FROM alpine:latest
+RUN apk add --no-cache bash
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh wait-for-it.sh
+RUN chmod +x wait-for-it.sh
+
+COPY --from=Build /minitwit/app /minitwit/app
+
 
 CMD ["/minitwit/app"]

--- a/minitwit-api/Dockerfile
+++ b/minitwit-api/Dockerfile
@@ -9,13 +9,14 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -v -o /minitwit/app .
 
-
 FROM alpine:latest
+WORKDIR /minitwit
 RUN apk add --no-cache bash
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh wait-for-it.sh
 RUN chmod +x wait-for-it.sh
 
 COPY --from=Build /minitwit/app /minitwit/app
 
-
+RUN chown -R 1000 /minitwit
+USER 1000:1000
 CMD ["/minitwit/app"]

--- a/minitwit-api/minitwit-api.go
+++ b/minitwit-api/minitwit-api.go
@@ -96,15 +96,15 @@ func main() {
 
 	pgImpl := &postgres.PostgresDbImplementation{}
 	sqliteImpl := &sqlite.SqliteDbImplementation{}
-	pgImpl.Connect_db()
-	sqliteImpl.Connect_db()
 
 	dbType := os.Getenv("DBTYPE")
 
 	if dbType == "postgres" {
+		pgImpl.Connect_db()
 		db.SetDb(pgImpl)
 		lg.Info("Using Postgress as main DB.")
 	} else {
+		sqliteImpl.Connect_db()
 		db.SetDb(sqliteImpl)
 		lg.Info("Using SQLite as main DB.")
 	}

--- a/minitwit-web-app/Dockerfile
+++ b/minitwit-web-app/Dockerfile
@@ -19,5 +19,6 @@ COPY  ./templates/ /minitwit/templates/
 COPY  ./static/ /minitwit/static/
 COPY --from=Build /minitwit/app /minitwit/app
 
-
+RUN chown -R 1000 /minitwit
+USER 1000:1000
 CMD ["/minitwit/app"]

--- a/minitwit-web-app/Dockerfile
+++ b/minitwit-web-app/Dockerfile
@@ -1,14 +1,23 @@
-FROM golang:1.22
+FROM golang:1.22-alpine3.19 AS Build
 
 WORKDIR /usr/src/app
-ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh wait-for-it.sh
-RUN chmod +x wait-for-it.sh
 
 # pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
 COPY *.go go.mod go.sum ./
 RUN go mod download && go mod verify
 
 COPY . .
-RUN go build -v -o /usr/local/bin/app ./...
+RUN go build -v -o /minitwit/app ./...
 
-CMD ["app"]
+FROM alpine:latest
+WORKDIR /minitwit
+RUN apk add --no-cache bash
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh wait-for-it.sh
+RUN chmod +x wait-for-it.sh
+
+COPY  ./templates/ /minitwit/templates/
+COPY  ./static/ /minitwit/static/
+COPY --from=Build /minitwit/app /minitwit/app
+
+
+CMD ["/minitwit/app"]

--- a/terraform/ephemeral/docker-compose.local.yml
+++ b/terraform/ephemeral/docker-compose.local.yml
@@ -10,7 +10,7 @@ services:
       - POSTGRES_DISABLE_SSL=true
   depends_on:
       - postgres
-  command: ["./wait-for-it.sh", "postgres:5432", "--", "/usr/local/bin/app"]
+  command: ["./wait-for-it.sh", "postgres:5432", "--", "/minitwit/app"]
 
   minitwit_api:
     build: ../../minitwit-api


### PR DESCRIPTION
Change dockerfiles to use multistage builds.
Update compose files to to match new paths.

Reduces size of API and APP from ~1GB to ~30MB