### PR TITLE
Added linters

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -16,8 +16,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run GoKart Linter
+      - name: Install  GoKart Linter
         run : |
           go install github.com/praetorian-inc/gokart@latest
+
+      - name: Run GoKart
+        run: |
           cd minitwit-web-app
           gokart scan
+        

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -81,3 +81,8 @@ jobs:
         run: |
           cd ./minitwit-web-app
           go vet ./...
+
+      - name: Run go vet
+        run: |
+          cd ./minitwit-api
+          go vet ./...

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -64,18 +64,18 @@ jobs:
 
   SourceCode: 
     runs-on: ubuntu-latest
-      permissions:
-        contents: read
-        packages: write
+    permissions:
+      contents: read
+      packages: write
 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Set up Go
-          uses: actions/setup-go@v2
-          with:
-            go-version: 1.17
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
 
-        - name: Run go vet
-          run: go vet ./...
+      - name: Run go vet
+        run: go vet ./...

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -45,5 +45,5 @@ jobs:
         - name: Hadolint
           run: |
             cd ./minitwit-web-app
-            docker run --rm -i hadolint/hadolint < Dockerfile
+            docker run -i hadolint/hadolint --format tty < Dockerfile
           continue-on-error: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 230-add-linters
+      
+  dispatch_workflow: 
 
 jobs:
   StaticCheck:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - 230-add-linters
-      
-  dispatch_workflow: 
+  workflow_dispatch: 
 
 jobs:
   StaticCheck:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -6,7 +6,7 @@ on:
       - 230-add-linters
 
 jobs:
-  build:
+  Static check:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,8 +16,33 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: golangci-lint
+      - name: API app
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
           working-directory: ./minitwit-api
+
+      - name: WEB app
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          working-directory: ./minitwit-web-app
+        continue-on-error: true
+
+
+
+  DockerFileCheck:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Hadolint
+          uses: hadolint/hadolint-action@v2.1.0
+          with:
+            dockerfile: Dockerfile
+          continue-on-error: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -16,10 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install  GoKart Linter
-        run : |
-          go install github.com/praetorian-inc/gokart@latest
-
-      - name: Run GoKart
-        run: |
-          gokart scan
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+              gokart scan

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -73,9 +73,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: 1.17
 
       - name: Run go vet
         run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -81,8 +81,11 @@ jobs:
         run: |
           cd ./minitwit-web-app
           go vet ./...
+        continue-on-error: true
+
 
       - name: Run go vet
         run: |
           cd ./minitwit-api
-          go vet ./...
+          go vet ./...        
+        continue-on-error: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -22,6 +22,4 @@ jobs:
 
       - name: Run GoKart
         run: |
-          cd minitwit-web-app
           gokart scan
-        

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -34,32 +34,32 @@ jobs:
 
 
   DockerFileCheck:
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-        packages: write
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Log into Docker
-          uses: docker/login-action@v3
-          with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Log into Docker
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
-        - name: Docker file - WEB app
-          run: |
-            cd ./minitwit-web-app
-            docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
-          continue-on-error: true
+      - name: Docker file - WEB app
+        run: |
+          cd ./minitwit-web-app
+          docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
+        continue-on-error: true
 
-        - name: Docker file - API app
-          run: |
-            cd ./minitwit-api
-            docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
-          continue-on-error: true
+      - name: Docker file - API app
+        run: |
+          cd ./minitwit-api
+          docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
+        continue-on-error: true
 
 
   SourceCode: 
@@ -78,4 +78,4 @@ jobs:
           go-version: 1.17
 
       - name: Run go vet
-        run: go vet ./...
+        run: go vet ./minitwit-web-app

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,4 +1,4 @@
-name: ci-cd
+name: Linters
 
 on:
   push:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           version: latest
           working-directory: ./minitwit-api
-          continue-on-error: true
+        continue-on-error: true
 
       - name: WEB app
         uses: golangci/golangci-lint-action@v2
@@ -43,8 +43,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Hadolint
-          uses: hadolint/hadolint-action@v2.1.0
-          with:
-            dockerfile: Dockerfile
-            working-directory: ./minitwit-web-app
+          run: |
+            cd ./minitwit-web-app
+            docker run --rm -i hadolint/hadolint < Dockerfile
           continue-on-error: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           version: latest
           working-directory: ./minitwit-api
+          continue-on-error: true
 
       - name: WEB app
         uses: golangci/golangci-lint-action@v2
@@ -45,4 +46,5 @@ jobs:
           uses: hadolint/hadolint-action@v2.1.0
           with:
             dockerfile: Dockerfile
+            working-directory: ./minitwit-web-app
           continue-on-error: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -16,6 +16,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Switch to API app 
+        run: |
+          echo "Current directory is $GITHUB_WORKSPACE"
+          cd ./minitwit-api
+          echo "Current directory is $GITHUB_WORKSPACE"
+
+
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
 
       - name: Run go vet
         run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -20,4 +20,3 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
-              gokart scan

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Run go vet
         run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -3,7 +3,7 @@ name: Linters
 on:
   push:
     branches:
-      - 230-add-linters
+      - main
   workflow_dispatch: 
 
 jobs:
@@ -30,8 +30,6 @@ jobs:
           version: latest
           working-directory: ./minitwit-web-app
         continue-on-error: true
-
-
 
   DockerFileCheck:
     runs-on: ubuntu-latest
@@ -77,14 +75,14 @@ jobs:
         with:
           go-version: 1.20
 
-      - name: Run go vet
+      - name: Web app lint
         run: |
           cd ./minitwit-web-app
           go vet ./...
         continue-on-error: true
 
 
-      - name: Run go vet
+      - name: API app lint
         run: |
           cd ./minitwit-api
           go vet ./...        

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -42,10 +42,11 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
 
-        - name: Install Docker
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y docker.io
+        - name: Log into Docker
+          uses: docker/login-action@v3
+          with:
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Hadolint
           run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: Run go vet
         run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -78,4 +78,6 @@ jobs:
           go-version: 1.17
 
       - name: Run go vet
-        run: go vet ./minitwit-web-app
+        run: |
+          cd ./minitwit-web-app
+          go vet ./...

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -16,12 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Switch to API app 
-        run: |
-          echo "Current directory is $GITHUB_WORKSPACE"
-          cd $GITHUB_WORKSPACE/minitwit-api
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
+          working-directory: ./minitwit-api

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -48,8 +48,14 @@ jobs:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_TOKEN }}
 
-        - name: Hadolint
+        - name: Docker file - WEB app
           run: |
             cd ./minitwit-web-app
+            docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
+          continue-on-error: true
+
+        - name: Docker file - API app
+          run: |
+            cd ./minitwit-api
             docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
           continue-on-error: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -45,6 +45,7 @@ jobs:
         - name: Log into Docker
           uses: docker/login-action@v3
           with:
+            registry: ${{ env.REGISTRY }}
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -6,7 +6,7 @@ on:
       - 230-add-linters
 
 jobs:
-  Static check:
+  StaticCheck:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -45,9 +45,8 @@ jobs:
         - name: Log into Docker
           uses: docker/login-action@v3
           with:
-            registry: ${{ env.REGISTRY }}
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_TOKEN }}
 
         - name: Hadolint
           run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -42,8 +42,13 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
 
+        - name: Install Docker
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+
         - name: Hadolint
           run: |
             cd ./minitwit-web-app
-            docker run -i hadolint/hadolint --format tty < Dockerfile
+            docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
           continue-on-error: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -19,10 +19,7 @@ jobs:
       - name: Switch to API app 
         run: |
           echo "Current directory is $GITHUB_WORKSPACE"
-          cd ./minitwit-api
-          echo "Current directory is $GITHUB_WORKSPACE"
-
-
+          cd $GITHUB_WORKSPACE/minitwit-api
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -60,3 +60,22 @@ jobs:
             cd ./minitwit-api
             docker run --rm -i -e HADOLINT_FORMAT=tty hadolint/hadolint < Dockerfile
           continue-on-error: true
+
+
+  SourceCode: 
+    runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Set up Go
+          uses: actions/setup-go@v2
+          with:
+            go-version: 1.17
+
+        - name: Run go vet
+          run: go vet ./...

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,23 @@
+name: ci-cd
+
+on:
+  push:
+    branches:
+      - 230-add-linters
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run GoKart Linter
+        run : |
+          go install github.com/praetorian-inc/gokart@latest
+          cd minitwit-web-app
+          gokart scan

--- a/minitwit-web-app/Dockerfile
+++ b/minitwit-web-app/Dockerfile
@@ -11,4 +11,4 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -v -o /usr/local/bin/app ./...
 
-CMD ["app"]
+CMD ["app"] asasadweedd

--- a/minitwit-web-app/Dockerfile
+++ b/minitwit-web-app/Dockerfile
@@ -11,4 +11,4 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -v -o /usr/local/bin/app ./...
 
-CMD ["app"] asasadweedd
+CMD ["app"]


### PR DESCRIPTION
Added 3 linters as we needed to have: 

1. golangci-lint --> analyzes your Go source code and reports various issues, bugs, and style violations. It combines the functionality of multiple linters into a single tool
2. Hadolint --> identify common issues and potential vulnerabilities in Dockerfile syntax and construction
3. GoVet --> static analysis tool that helps identify common mistakes and potential bugs in Go programs

Action will always end as successful ( this way all the linters can do its job ) so for errors please check the logs of the steps. I am also not adding this to CI/CD pipeline since it will fail almost all the time due to error linters find. Error that we are getting now are more "cosmetic" and do not affect the app as itself. We can run linters manually to check for the app state. 